### PR TITLE
fix: [KAN-34] deployment err

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           docker stop ceramicraft-user-mservice || true
           docker rm ceramicraft-user-mservice || true
-          docker run -d --name ceramicraft-user-mservice --network ceramicraft-network -p 8080:8080 "${DOCKER_HUB_USERNAME}/ceramicraft-user-mservice:${{ github.event.inputs.version }}"
+          docker run -d --name ceramicraft-user-mservice --network ceramicraft-network -e MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }} -p 8080:8080 "${DOCKER_HUB_USERNAME}/ceramicraft-user-mservice:${{ github.event.inputs.version }}"
   restart:
     if: ${{ github.event.inputs.command == 'restart' }}
     runs-on: self-hosted

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -18,11 +18,11 @@ RUN go build -ldflags="-s -w" -o main main.go
 
 # Create a non-root user and set permissions
 RUN useradd -m appuser && \
-    mkdir -p log && \
+    mkdir -p logs && \
     chown -R appuser:appuser config/ && \
-    chown -R appuser:appuser log/ && \
+    chown -R appuser:appuser logs/ && \
     chmod +r config/* && \
-    chmod +w log && \
+    chmod +w logs && \
     chmod +x main
 
 EXPOSE 8080

--- a/server/resources/config.yml
+++ b/server/resources/config.yml
@@ -10,7 +10,7 @@ http:
 
 log:
   level: debug
-  file_path: ./logs/user-server.log
+  file_path: ./logs/ceramicraft-user-mservice.log
 
 mysql:
   host: "mysql-container"


### PR DESCRIPTION
---
name: fix deployment bug
about: depoymeng fail with missing env var & log write permission
labels: ["fix"]
---

## 变更内容 | Changes
1. Dockerfile: chmod +w logs
2. deployment.yml: add docker run env

## 相关 Issue | Related Issue
[KAN-34 User Service Deployment Fail](https://cerami-craft.atlassian.net/browse/KAN-34)

## 变更类型 | Type of Change
- [ ] 新功能 Feature
- [x] 修复 Bug Fix
- [ ] 文档 Documentation
- [ ] 样式优化 Style
- [ ] 重构 Refactor
- [ ] 性能优化 Performance
- [ ] 测试 Test
- [x] 构建/CI Build/CI
- [ ] 其他 Other

## 检查清单 | Checklist
- [x] 代码已通过本地测试（含主流浏览器/终端）| Code tested locally (including major browsers/terminals)
- [ ] 相关文档已更新（如有）| Documentation updated if needed
- [ ] 代码风格符合项目规范 | Code style follows project conventions
- [x] 变更不会影响现有功能 | Changes do not break existing features
- [x] 已自查无敏感信息泄露 | No sensitive info is leaked

## 变更影响 | Impact
none

## 测试说明 | Test Instructions
none

## 其他说明 | Additional Notes
<!-- 其他需要说明的内容 | Any other notes -->
